### PR TITLE
Fix authorization header scheme for task completion

### DIFF
--- a/core/api/dawn.py
+++ b/core/api/dawn.py
@@ -395,7 +395,7 @@ class DawnExtensionAPI(APIClient):
             tasks = ["telegramid", "discordid", "twitter_x_id"]
 
         headers = {
-            'authorization': f'Brearer {self.auth_token}',
+            'authorization': f'Bearer {self.auth_token}',
             'user-agent': self.user_agent,
             'content-type': 'application/json',
             'accept': '*/*',


### PR DESCRIPTION
## Summary
- correct typo in Authorization header for task completion API to use `Bearer`

## Testing
- `python -m py_compile core/api/dawn.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7bdaa7b5c832692c402949b537f2d