### PR TITLE
Handle non-JSON task responses and fix auth headers

### DIFF
--- a/core/api/dawn.py
+++ b/core/api/dawn.py
@@ -275,7 +275,7 @@ class DawnExtensionAPI(APIClient):
         headers = {
             'user-agent': self.user_agent,
             'content-type': 'application/json',
-            'authorization': f'Berear {self.auth_token}',
+            'authorization': f'Bearer {self.auth_token}',
             'accept': '*/*',
             'origin': 'chrome-extension://fpdkjdnhkakefebpekbdhillbhonfjjp',
             'accept-language': 'uk-UA,uk;q=0.9,en-US;q=0.8,en;q=0.7',
@@ -301,7 +301,7 @@ class DawnExtensionAPI(APIClient):
     @require_auth_token
     async def user_info(self, app_id: str) -> dict:
         headers = {
-            'authorization': f'Berear {self.auth_token}',
+            'authorization': f'Bearer {self.auth_token}',
             'user-agent': self.user_agent,
             'content-type': 'application/json',
             'accept': '*/*',
@@ -395,7 +395,7 @@ class DawnExtensionAPI(APIClient):
             tasks = ["telegramid", "discordid", "twitter_x_id"]
 
         headers = {
-            'authorization': f'Brearer {self.auth_token}',
+            'authorization': f'Bearer {self.auth_token}',
             'user-agent': self.user_agent,
             'content-type': 'application/json',
             'accept': '*/*',
@@ -410,6 +410,7 @@ class DawnExtensionAPI(APIClient):
                 json_data={task: task},
                 headers=headers,
                 params={"appid": app_id},
+                verify=False,
             )
 
             await asyncio.sleep(delay)


### PR DESCRIPTION
## Summary
- use correct `Bearer` scheme for keepalive and user info requests
- allow task updates to skip JSON parsing so empty responses don't raise errors

## Testing
- `python -m py_compile core/api/dawn.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7bdaa7b5c832692c402949b537f2d